### PR TITLE
add a link in TOC to examples page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,6 +38,7 @@ class MainPage extends Tonic {
               <a href="#styles">Styles</a>
               <a href="#ssr">SSR</a>
               <a href="#csp">CSP</a>
+              <a href="/examples.html">Examples</a>
             </toc-nav>
           </aside>
 


### PR DESCRIPTION
Add a link in the TOC sidebar section. Fix for https://github.com/socketsupply/tonic/issues/96

