### PR TITLE
fix some visual overflow issues on smaller viewports

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -99,7 +99,7 @@ code {
 
 pre {
   padding: 14px;
-  overflow: overlay;
+  overflow: auto;
 }
 
 aside {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -267,6 +267,11 @@ main .logo svg {
     display: block;
   }
 
+  div.title h1 {
+    font-size: 48px;
+    line-height: 48px;
+  }
+
   .checklists main {
     padding: 50px 10%;
   }


### PR DESCRIPTION
Fixes the following (all screenshots use Firefox reponsive design mode on Firefox MacOS with viewport setting _iPhone 12/13 Pro Max iOS 14.6, 428x926_):

1. Title header font size a little too large for mobile viewports. Changes from 60px to 48px for `@media (max-width: 768px)` media query

  - Before
  
    <img width="429" alt="image" src="https://user-images.githubusercontent.com/18542095/213290463-b205c88a-82e3-4159-87c7-6115440b0101.png">
    
  - After

    <img width="429" alt="image" src="https://user-images.githubusercontent.com/18542095/213290589-964d9a4e-a8c6-435f-8bee-8e239bd1311e.png">


2. Overflow issues for code blocks on Firefox. `overflow: overlay` is [deprecated and no longer applied](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#values) on Firefox, causing an issue.

  - Before
  
    <img width="429" alt="image" src="https://user-images.githubusercontent.com/18542095/213290133-4fdd22de-31dc-47b8-a761-3f92fe33660a.png">

    
  - After (don't worry, scrollbar will show up when scrolling within the block, just didn't capture in screenshot)
    
    <img width="429" alt="image" src="https://user-images.githubusercontent.com/18542095/213290035-6ef74ed3-022c-40b9-bcc1-73c2bb859c11.png">

